### PR TITLE
fix(crawler): stop Last.fm backfill self-retrigger loop

### DIFF
--- a/.github/workflows/listeners_backfill.yml
+++ b/.github/workflows/listeners_backfill.yml
@@ -49,6 +49,7 @@ jobs:
           REMAINING=$(psql "$DATABASE_URL" -t -c "
             SELECT COUNT(*) FROM \"Disco\"
             WHERE lastfm_listeners IS NULL AND disponivel = TRUE
+              AND (format IS NULL OR format = 'vinyl')
               AND artista !~* 'artista n[ãa]o identificad'
           " | tr -d ' ')
           echo "Remaining NULL-listener rows: $REMAINING"

--- a/crawler/backfill_listeners.py
+++ b/crawler/backfill_listeners.py
@@ -62,6 +62,7 @@ def main():
         cur.execute(
             """SELECT count(*) FROM "Disco"
                WHERE lastfm_listeners IS NULL AND disponivel = TRUE
+                 AND (format IS NULL OR format = 'vinyl')
                  AND artista !~* 'artista n[ãa]o identificad'"""
         )
         start_null = cur.fetchone()[0]


### PR DESCRIPTION
## Problem

`listeners_backfill.yml` has re-dispatched itself every ~20s since 2026-07-01 — **25,423 runs**. Each one succeeds, enriches 0 rows, and re-triggers.

The drainer pulls rows via `fetch_albums_needing_lastfm_enrichment`, which filters on `(format IS NULL OR format = 'vinyl')`. The two **count** queries did not:

- `crawler/backfill_listeners.py` — the `start_null` count
- `.github/workflows/listeners_backfill.yml` — the re-trigger gate

Once the vinyl backlog drained, the fetch returned 0 rows → script logged `"No more NULL rows — drain complete."` → the counts still saw 11,295 non-vinyl rows → `gh workflow run` → repeat, forever.

Backlog composition (live DB):

| format | rows |
|---|---|
| `other` | 5,814 |
| `cd` | 5,481 |
| **visible to the fetch query** | **0** |

Repo is public, so Actions minutes are free — no billing impact. The cost was 25k runs of noise and a DB hit every 20s.

## Fix

Add the same `format` filter to both counts so all three queries agree.

## Verification

Against the live DB, post-patch:

```
patched count query  -> 0
fetch query          -> 0
re-trigger fires?    -> NO (chain stops)
```

`backfill_listeners.py` compiles; `listeners_backfill.yml` parses.

## Note

The 11,295 non-vinyl rows will never get Last.fm listeners. That is correct for a vinyl-only drainer, but the `other` bucket is 5,814 rows — worth a separate look at whether that is unclassified vinyl rather than genuinely non-vinyl. Not addressed here.

## Deploy

Workflow is currently `disabled_manually` (that is what stopped the loop). Re-enable after merge:

```
gh workflow enable listeners_backfill.yml
```

It will run at 01:10 UTC, count 0, and idle — as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)